### PR TITLE
Fix url for Stadtbibliothek Leipzig

### DIFF
--- a/data/libraries/DE_Sachsen_Leipzig_Stb.xml
+++ b/data/libraries/DE_Sachsen_Leipzig_Stb.xml
@@ -6,7 +6,7 @@
   <shortName value="Stb Leipzig"/> 
   
   <template value="sisis"/>  
-  <variable name="server" value="https://webopac.stadtbibliothek-leipzig.de/webOPACClient/"/>
+  <variable name="server" value="https://bibliothekskatalog.leipzig.de/webOPACClient/"/>
   
   <homepage value="http://www.leipzig.de/stadtbib/"/>
   <testing-search value="yes"/>


### PR DESCRIPTION
Thanks a lot for this great app. I'm using it regularly.
But recently, I don't get any updates for "Stadtbibliothek Leipzig" anymore.

It seems they changed the url to the catalog. Previous it was https://webopac.stadtbibliothek-leipzig.de/ and now the catalog is available at [https://bibliothekskatalog.leipzig.de/.](https://bibliothekskatalog.leipzig.de/)

~Unfortunately, I don't know how to test this change myself.~
I successfully tested this updated definition file in the installed Desktop version 2.920-1 of the software.


If something is wrong, please let me know.

Best regards
